### PR TITLE
Fix issues with finding hidapi library

### DIFF
--- a/lda/hidapi.py
+++ b/lda/hidapi.py
@@ -13,10 +13,10 @@ if hidapi_lib_path is None:
         os.environ["PATH"] += ";{}".format(dir)
 
     for n in "hidapi-libusb hidapi-hidraw hidapi".split():
-        path = ctypes.util.find_library(n)
-        if path:
+        hidapi_lib_path = ctypes.util.find_library(n)
+        if hidapi_lib_path:
             break
-    if not path:
+    if not hidapi_lib_path:
         raise ImportError("no hidapi library found")
 
 hidapi = ctypes.CDLL(hidapi_lib_path)


### PR DESCRIPTION
We haven't used this library in a while (possibly since it was moved out of the main artiq branch), on trying to use it this error appeared:

```
(artiq-beta) C:\Users\rabi>aqctl_lda -p 4000 -P LDA-102 -d SN:00434
Traceback (most recent call last):
  File "C:\Anaconda3\envs\artiq-beta\Scripts\aqctl_lda-script.py", line 9, in <module>
    sys.exit(main())
  File "C:\Anaconda3\envs\artiq-beta\lib\site-packages\lda\aqctl_lda.py", line 36, in main
    lda = Lda(args.device, args.product)
  File "C:\Anaconda3\envs\artiq-beta\lib\site-packages\lda\driver.py", line 98, in __init__
    from lda.hidapi import hidapi
  File "C:\Anaconda3\envs\artiq-beta\lib\site-packages\lda\hidapi.py", line 22, in <module>
    hidapi = ctypes.CDLL(hidapi_lib_path)
  File "C:\Anaconda3\envs\artiq-beta\lib\ctypes\__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be str, not None
```

This error is only possible if the hidapi dll is found, but the path is not set. The below commit fixes the issue (provided of course that the dll has been copied into the relevant directory for Windows).